### PR TITLE
added ContainsAllMatcher

### DIFF
--- a/src/main/kotlin/com/natpryce/hamkrest/collection_matchers.kt
+++ b/src/main/kotlin/com/natpryce/hamkrest/collection_matchers.kt
@@ -65,3 +65,79 @@ fun <T> isIn(i: Iterable<T>) : Matcher<T> = object : Matcher.Primitive<T>() {
 }
 
 fun <T> isIn(vararg elements: T) = isIn(elements.toList())
+
+
+fun <T> containsAll(vararg elements: T, matcher: (T) -> Matcher<T> = { equalTo(it) }): Matcher<Iterable<T>> {
+    return containsAll(elements.map{ matcher(it) })
+}
+
+fun <T> containsAll(elements: Iterable<T>, matcher: (T) -> Matcher<T> = { equalTo(it) }): Matcher<Iterable<T>> {
+    return containsAll(elements.map { matcher(it) })
+}
+
+fun <T> containsAll(vararg elementMatchers: Matcher<T>): Matcher<Iterable<T>> {
+    return containsAll(elementMatchers.toList())
+}
+
+/**
+ * Matches an [Iterable] if for each element there is one corresponding matcher.
+ */
+fun <T> containsAll(elementMatchers: Iterable<Matcher<T>>): Matcher<Iterable<T>> {
+    return ContainsAllMatcher(elementMatchers)
+}
+
+/**
+ * Matches an [Iterable] if it contains all the elements in any order
+ * and nested [Iterable]s match according to the same rules.
+ */
+fun <T> containsAllNested(elements: Iterable<T>, leafMatcher: (T) -> Matcher<T> = { equalTo(it) }): Matcher<Iterable<T>> {
+    if (elements.count() > 0 && elements.first() is Iterable<*>) {
+        @Suppress("UNCHECKED_CAST")
+        return containsAll(elements.map { containsAll(it as Iterable<*>) as Matcher<T> })
+    } else {
+        return containsAll(elements.map { leafMatcher(it) })
+    }
+}
+
+
+internal class ContainsAllMatcher<in T>(val matchers: Iterable<Matcher<T>>) : Matcher<Iterable<T>> {
+
+    override fun invoke(actual: Iterable<T>): MatchResult {
+        val matching = Matching(matchers)
+        for (element in actual) {
+            val matchResult = matching.matches(element)
+            if (matchResult != MatchResult.Match) {
+                return matchResult
+            }
+        }
+        return matching.isFinished(actual)
+    }
+
+    override val description: String
+        get() = "iterable with elements [${matchers.joinToString{ it.description }}] in any order"
+
+
+    private class Matching<in S>(matchers: Iterable<Matcher<S>>) {
+        private val matchers = matchers.toMutableList()
+
+        fun matches(element: S): MatchResult {
+            if (matchers.isEmpty()) {
+                return MatchResult.Mismatch("no match for: $element")
+            }
+            for (matcher in matchers) {
+                if (matcher.invoke(element) == MatchResult.Match) {
+                    matchers.remove(matcher)
+                    return MatchResult.Match
+                }
+            }
+            return MatchResult.Mismatch("not matched: $element")
+        }
+
+        fun isFinished(elements: Iterable<S>): MatchResult {
+            if (matchers.isEmpty()) {
+                return MatchResult.Match
+            }
+            return MatchResult.Mismatch("no element matches: [${matchers.joinToString{ it.description }}] in [${elements.joinToString()}]")
+        }
+    }
+}

--- a/src/test/kotlin/com/natpryce/hamkrest/collection_matchers_tests.kt
+++ b/src/test/kotlin/com/natpryce/hamkrest/collection_matchers_tests.kt
@@ -1,6 +1,7 @@
 package com.natpryce.hamkrest
 
 import com.natpryce.hamkrest.assertion.assertThat
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 
@@ -70,7 +71,6 @@ class IsIn {
     }
 }
 
-
 class CollectionSize {
     @Test
     fun size() {
@@ -97,5 +97,86 @@ class CollectionSize {
     fun empty_description() {
         assertThat(isEmpty.description, equalTo("is empty"))
         assertThat((!isEmpty).description, equalTo("is not empty"))
+    }
+}
+
+class ContainsAllTest {
+    @Test
+    fun empty_iterable() {
+        assertThat(emptyList<Int>(), containsAll(emptyList()))
+        assertThat(emptyList<Int>(), !containsAll(anything))
+        assertThat(listOf(anything), !containsAll(emptyList<Any>()))
+    }
+
+    @Test
+    fun matching_iterables() {
+        assertThat(listOf(1), containsAll(1))
+        assertThat(listOf(1), containsAll(equalTo(1)))
+
+        assertThat(listOf(1, 1), containsAll(1, 1))
+        assertThat(listOf(1, 2), containsAll(1, 2))
+        assertThat(listOf(2, 1), containsAll(1, 2))
+
+        assertThat(listOf(1, 2, 2), containsAll(2, 2, 1))
+        assertThat(listOf(1, 2, 3), containsAll(2, 3, 1))
+    }
+
+    @Test
+    fun mismatching_iterables() {
+        assertThat("one element is different", listOf(1, 2, 3), !containsAll(4, 2, 1))
+        assertThat("disjoint sets", listOf(1, 2), !containsAll(3, 4))
+        assertThat("expected is subset", listOf(1, 2, 3), !containsAll(1, 2))
+        assertThat("actual is subset", listOf(1, 2), !containsAll(1, 2, 3))
+    }
+
+    @Test
+    fun different_amount_of_elements() {
+        assertThat(listOf(1, 1), !containsAll(1))
+        assertThat(listOf(1), !containsAll(1, 1))
+        assertThat(listOf(1, 2, 2), !containsAll(1, 1, 2))
+    }
+
+    @Test
+    fun nested_iterables() {
+        assertThat(listOf(emptyList()), containsAllNested(listOf(emptyList<Int>())))
+        assertThat(listOf(listOf(1)), containsAllNested(listOf(listOf(1))))
+
+        assertThat(listOf(listOf(1, 2)), containsAllNested(listOf(listOf(2, 1))))
+        assertThat(listOf(listOf(1, 1, 2)), containsAllNested(listOf(listOf(2, 1, 1))))
+
+        assertThat(listOf(listOf(1, 2, 3), listOf(1)), containsAllNested(listOf(listOf(1), listOf(3, 2, 1))))
+        assertThat(listOf(listOf(1, 2, 4), listOf(1)), containsAllNested(listOf(listOf(1), listOf(4, 2, 1))))
+    }
+
+    @Test
+    fun description() {
+        assertThat(containsAll(1, 2).description, equalTo("iterable with elements [is equal to 1, is equal to 2] in any order"))
+    }
+
+    @Test
+    fun mismatch_description() {
+        assertThat(mismatchDescriptionOf(emptyList(), containsAll(1, 2)), equalTo("no element matches: [is equal to 1, is equal to 2] in []"))
+        assertThat(mismatchDescriptionOf(listOf(1, 2, 4), containsAll(1, 2, 3)), equalTo("not matched: 4"))
+        assertThat(mismatchDescriptionOf(listOf(1, 2, 2), containsAll(2, 1, 1)), equalTo("not matched: 2"))
+        assertThat(mismatchDescriptionOf(listOf(1, 2, 3), containsAll(1, 3)), equalTo("not matched: 2"))
+        assertThat(mismatchDescriptionOf(listOf(1, 2), containsAll(1, 2, 3)), equalTo("no element matches: [is equal to 3] in [1, 2]"))
+    }
+
+    @Test
+    fun clash_with_builtin_containsAll_function() {
+        listOf(1, 2).apply {
+            assertThat(this, com.natpryce.hamkrest.containsAll(listOf(1, 2)))
+            //               ^^^^^^^^^^^^ have to use qualified name to avoid conflict with kotlin.collections.List.containsAll
+        }
+        listOf(listOf(1, 2)).apply {
+            assertThat(this, anyElement(com.natpryce.hamkrest.containsAll(listOf(1, 2))))
+            //                          ^^^^^^^^^^^^ have to use qualified name to avoid conflict with kotlin.collections.containsAll
+        }
+    }
+
+    private fun <T> mismatchDescriptionOf(arg: T, matcher: Matcher<T>): String {
+        val matchResult = matcher.invoke(arg)
+        assertTrue("Precondition: Matcher should not match item.", matchResult is MatchResult.Mismatch)
+        return (matchResult as MatchResult.Mismatch).description
     }
 }


### PR DESCRIPTION
I called the matcher `containsAll`but there are couple problems with this name:
- this matcher is based on `IsIterableContainingInAnyOrder` which means "equal iterables ignoring order of elements". It's not the same as equal `Set` objects and not the same as `Collection.containsAll`.
- when used inside `apply` closure, it clashes with built-in `containsAll` function (see https://github.com/dkandalov/hamkrest/blob/c421c419294236336db8000bae1325321889208b/src/test/kotlin/com/natpryce/hamkrest/collection_matchers_tests.kt#L166-L166)

I also have doubts that current mismatch description is good. Also passing custom "equality" matcher and nested iterables API looks a bit clunky.
