### PR TITLE
Fix issue #23 - upgrade to Kotlin 1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ version(hasProperty("-version") ? property("-version") : "SNAPSHOT")
 println "building version ${version}"
 
 buildscript {
-    ext.kotlin_version = '1.0.3'
+    ext.kotlin_version = '1.1.1'
     repositories {
         mavenCentral()
         jcenter()

--- a/src/main/kotlin/com/natpryce/hamkrest/matching.kt
+++ b/src/main/kotlin/com/natpryce/hamkrest/matching.kt
@@ -246,7 +246,7 @@ fun <T, R> has(name: String, feature: (T) -> R, featureMatcher: Matcher<R>): Mat
  * Returns a matcher that applies [propertyMatcher] to the current value of [property] of an object.
  */
 fun <T, R> has(property: KProperty1<T, R>, propertyMatcher: Matcher<R>): Matcher<T> =
-    has(identifierToDescription(property.name), property.getter, propertyMatcher)
+    has(identifierToDescription(property.name), property, propertyMatcher)
 
 
 /**

--- a/src/test/kotlin/com/natpryce/hamkrest/matching_tests.kt
+++ b/src/test/kotlin/com/natpryce/hamkrest/matching_tests.kt
@@ -127,13 +127,15 @@ class Projections {
 
     @Test
     fun can_match_projection_by_function() {
-        assertThat("12345", has(String::toInt, equalTo(12345)))
-        assertThat("1234", !has(String::toInt, equalTo(12345)))
+        assertThat("12345", has(::toInt, equalTo(12345)))
+        assertThat("1234", !has(::toInt, equalTo(12345)))
     }
 
     @Test
     fun description_of_projection_is_human_readableified() {
-        assertThat(has(String::toInt, equalTo(12345)).description, equalTo(
+        assertThat(has(::toInt, equalTo(12345)).description, equalTo(
                 "has to int that is equal to 12345"))
     }
 }
+
+fun toInt(s: String) : Int = s.toInt()


### PR DESCRIPTION
- Accessing getter on property was causing reflection issues.
- toInt became ambiguous with the introduction of toInt(radix). Created a local function to resolve it, not great but allows the tests to show the use of has() with functions.