### PR TITLE
Syntactic sugar for equality assertions

### DIFF
--- a/src/main/kotlin/com/natpryce/hamkrest/should/should.kt
+++ b/src/main/kotlin/com/natpryce/hamkrest/should/should.kt
@@ -5,6 +5,7 @@ package com.natpryce.hamkrest.should
 import com.natpryce.hamkrest.Described
 import com.natpryce.hamkrest.Matcher
 import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
 import kotlin.reflect.KFunction1
 
 
@@ -53,3 +54,10 @@ infix fun <T> Described<T>.shouldMatch(criteria: Matcher<T>) = assertThat(this.d
  * Syntactic sugar for [assertThat] that can be used as an infix function.
  */
 infix fun <T> Described<T>.shouldMatch(p: KFunction1<T, Boolean>) = assertThat(this.description, this.value, Matcher(p))
+
+/**
+ * Syntactic sugar for the common case of asserting equality.
+ */
+infix fun <T> T.shouldEqual(expected: T) {
+  this shouldMatch equalTo(expected)
+}

--- a/src/test/kotlin/com/natpryce/hamkrest/should/should_extension.kt
+++ b/src/test/kotlin/com/natpryce/hamkrest/should/should_extension.kt
@@ -59,6 +59,11 @@ class ShouldExtension {
     fun not_matches_subtypes() {
         listOf(1, 2, 4) shouldNotMatch anyElement(equalTo(3))
     }
+
+    @Test
+    fun should_equal_asserts_equality() {
+        "Banana" shouldEqual "Banana"
+    }
 }
 
 private fun isAYellowFruitName(name: String) = name.toLowerCase() in listOf("banana", "lemon", "hippophae")


### PR DESCRIPTION
`assertThat(x, equalTo(y))` and `x shouldMatch equalTo(y)` are so common it seems useful to be able to shorten them to `x shouldBe y`.