### PR TITLE
Create a Matcher from a KProperty1

### DIFF
--- a/src/test/kotlin/com/natpryce/hamkrest/core_matchers_tests.kt
+++ b/src/test/kotlin/com/natpryce/hamkrest/core_matchers_tests.kt
@@ -163,3 +163,13 @@ class Throwing {
         assert.that({throw DifferentException("xxx")}, !throws<ExampleException>())
     }
 }
+
+class Converting {
+
+    data class HasProperty(val hasAProperty: Boolean)
+
+    @Test
+    fun create_from_a_property() {
+        assert.that(HasProperty(true), Matcher(HasProperty::hasAProperty))
+    }
+}


### PR DESCRIPTION
Opens the door to quickly creating matchers from Boolean properties.

I think there's a subsequent change to allow either a sugary factory method you could use e.g. a `thatIs` matcher that could be used like `assertThat(response, has(Response::Status, thatIs(Status::successful)))`. Another alternative would be introducing`has(property: KProperty1<T, R>, propertyMatcher: KProperty1<R, Boolean>)` such that `has(Response::Status, Status::successful)`. That seems quite niche though, "boolean property of a property".