### PR TITLE
Change assertion output to allow IntelliJ to offer its diff tool for output comparison

### DIFF
--- a/src/main/kotlin/com/natpryce/hamkrest/assertion/assert.kt
+++ b/src/main/kotlin/com/natpryce/hamkrest/assertion/assert.kt
@@ -16,8 +16,8 @@ class Assertion(val valueDescriber: (Any?) -> String) {
         if (judgement is MatchResult.Mismatch) {
             throw AssertionError(
                 message().let { if (it.isEmpty()) it else it + ": " } +
-                    "expected a value that ${valueDescriber(criteria)}\n" +
-                    "but it ${valueDescriber(judgement)}")
+                    "expected: a value that ${valueDescriber(criteria)}\n" +
+                    "but ${valueDescriber(judgement)}")
         }
     }
 }

--- a/src/test/kotlin/com/natpryce/hamkrest/assertion/assert_tests.kt
+++ b/src/test/kotlin/com/natpryce/hamkrest/assertion/assert_tests.kt
@@ -1,0 +1,17 @@
+package com.natpryce.hamkrest.assertion
+
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.matches
+import org.junit.Test
+import kotlin.text.RegexOption.*
+
+class AssertOutput {
+    @Test
+    fun produces_ide_friendly() {
+        try {
+            assert.that("foo", equalTo("bar"))
+        } catch (e: AssertionError) {
+            assert.that(e.message!!, matches(Regex("expected: .*but was: .*", setOf(MULTILINE, DOT_MATCHES_ALL))))
+        }
+    }
+}


### PR DESCRIPTION
It's worth noticing that this would make the message slightly less nice to read.

Before this change:

```
java.lang.AssertionError: expected a value that matches a(b*)a
but it was: "aabbbbbba"
```

After:

```
java.lang.AssertionError: expected: a value that matches a(b*)a
but was: "aabbbbbba"
```

I believe that's a small price to pay for the diff tool, but wouldn't be surprised if I've missed some other cases where this becomes a bigger problem.
