### PR TITLE
 Improve failure message for absent() matcher

### DIFF
--- a/src/commonMain/kotlin/com/natpryce/hamkrest/core_matchers.kt
+++ b/src/commonMain/kotlin/com/natpryce/hamkrest/core_matchers.kt
@@ -44,7 +44,7 @@ fun <T> sameInstance(expected: T): Matcher<T> =
  */
 fun <T> absent(): Matcher<T?> = object : PrimitiveMatcher<T?>() {
     override fun invoke(actual: T?): MatchResult = match(actual == null) { "was: ${describe(actual)}" }
-    override val description: String get() = "null"
+    override val description: String get() = "is null"
 }
 
 /**

--- a/src/commonTest/kotlin/com/natpryce/hamkrest/core_matchers_tests.kt
+++ b/src/commonTest/kotlin/com/natpryce/hamkrest/core_matchers_tests.kt
@@ -126,7 +126,7 @@ class Nullability {
         val m : Matcher<String?> = absent()
         val n : Matcher<String?> = present()
 
-        assertEquals("null", m.description)
+        assertEquals("is null", m.description)
         assertEquals("is not null", n.description)
         val valueMatcher = equalTo("test")
         assertEquals("is not null & " + valueMatcher.description, present(valueMatcher).description)

--- a/src/commonTest/kotlin/com/natpryce/hamkrest/core_matchers_tests.kt
+++ b/src/commonTest/kotlin/com/natpryce/hamkrest/core_matchers_tests.kt
@@ -120,6 +120,17 @@ class Nullability {
         assertMismatchWithDescription("was: null", m(null))
         assertMismatchWithDescription("was: \"yyy\"", m("yyy"))
     }
+
+    @Test
+    fun description() {
+        val m : Matcher<String?> = absent()
+        val n : Matcher<String?> = present()
+
+        assertEquals("null", m.description)
+        assertEquals("is not null", n.description)
+        val valueMatcher = equalTo("test")
+        assertEquals("is not null & " + valueMatcher.description, present(valueMatcher).description)
+    }
 }
 
 class Downcasting {


### PR DESCRIPTION
I noticed that the failure message for the `absent()` matcher read "expected: a value that null", instead of "a value that _is_ null", the way other matchers' descriptions were written. It was a minor tweak to change it, although I had to first add a new unit test for the `absent` and `present` matcher descriptions, as these were missing.

The new test, against the _original_ code, is in the first commit; the proposed change is in the second commit. If you would prefer to separate PRs (since the first is not a change in behaviour), I can certainly do that. I just wondered if the changes would be considered too trivial on as separate items.